### PR TITLE
close notify box on click #19

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -131,8 +131,10 @@ var background = {
 
         chrome.notifications.onClicked.addListener(function(notificationId){
             // close notification popup
-            chrome.notifications.clear(notificationId, function(){
-                // do nothing
+            chrome.notifications.clear(notificationId, function(wasCleared){
+                // open gitlab event page (Issue, MergeRequest, Milestone)
+                var notification = JSON.parse(notificationId);
+                chrome.tabs.create({url: notification.target_url});
             });
         });
 


### PR DESCRIPTION
#19
- close notification popup when click in main area
- add button "open Gitlab page"

![2013-11-24 23 54 52](https://f.cloud.github.com/assets/608755/1608833/8b3970dc-5518-11e3-8d09-147d866bf2b0.png)
