### PR TITLE
Add trailing slash to gitlabPath and apiPath on save settings

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -109,8 +109,8 @@ var config= (function(){
     function save(args){
         util.checkArgs(args, ["gitlabPath", "privateToken", "privateToken", "pollingSecond", "maxEventCount", "maxNotificationCount", "newMarkMinute", "projects"]);
 
-        localStorage.gitlabPath           = args.gitlabPath;
-        localStorage.apiPath              = args.apiPath;
+        localStorage.gitlabPath           = util.addTrailingSlash(args.gitlabPath);
+        localStorage.apiPath              = util.addTrailingSlash(args.apiPath);
         localStorage.privateToken         = args.privateToken;
         localStorage.pollingSecond        = args.pollingSecond;
         localStorage.maxEventCount        = args.maxEventCount;

--- a/src/util.js
+++ b/src/util.js
@@ -43,7 +43,7 @@ var util = (function(){
     function addTrailingSlash(url){
         if (typeof url !== "string") return url;
         if (url === "" || url.match(/\/$/)) return url;
-        return url += '/';
+        return url + '/';
     }
 
     return {

--- a/src/util.js
+++ b/src/util.js
@@ -40,12 +40,19 @@ var util = (function(){
         return MD5_hexhash(JSON.stringify(obj));
     }
 
+    function addTrailingSlash(url){
+        if (typeof url !== "string") return url;
+        if (url === "" || url.match(/\/$/)) return url;
+        return url += '/';
+    }
+
     return {
         checkArgs:       checkArgs,
         createEventIcon: createEventIcon,
         isChecked:       isChecked,
         toInt:           toInt,
-        calcHash:        calcHash
+        calcHash:        calcHash,
+        addTrailingSlash: addTrailingSlash
     };
 
     // private methods


### PR DESCRIPTION
Hi,

Links to commits were broken when I forgot to add trailing slash to GitLab Path & GitLab API Path settings.
So I've made little util to add trailing slash at the point user save their settings.

Hope it helps.