### PR TITLE
Add the 'pushed to' label to the popup window

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -2,7 +2,8 @@
     var actionLabels = {
         "opened"   : "label-warning",
         "closed"   : "label-danger",
-        "accepted" : "label-success"
+        "accepted" : "label-success",
+        "pushed to": "label-info"
     };
 
     $(document).ready(function(){


### PR DESCRIPTION
Gitlab add a new label "pushed to" to its API.
Here is the rendering:

![1](https://cloud.githubusercontent.com/assets/752030/6393411/1b724e88-bdca-11e4-8019-ec50bf18c2de.jpg)
