### PR TITLE
Tweak projects list at option page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## development
 [full changelog](https://github.com/sue445/chrome-gitlab-notifier/compare/1.1.2...master)
 
+* Tweak projects list at option page
+  * https://github.com/sue445/chrome-gitlab-notifier/pull/55
+  * Sort by project name (for GitLab v7.7.0+)
+  * Add project archived icon
+
 ## 1.1.3 (2015/03/01)
 
 * Add the 'pushed to' label to the popup window (thx. @brunosabot)

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -87,11 +87,14 @@ var gitlab= (function(){
         // List projects
         // GET /projects
         // https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/projects.md#list-projects
+        // NOTE: order_by and sort are supported by v7.7.0+. If no options, order_by created_at DESC
         $.ajax({
             url: config.getApiPath() + "projects",
             data: {
                 page: page,
-                per_page: per_page
+                per_page: per_page,
+                order_by: "name",
+                sort:     "asc"
             },
             type: "GET",
             dataType: "json",

--- a/src/options.js
+++ b/src/options.js
@@ -54,9 +54,12 @@
 
                 var project_url = config.getGitlabPath() + project.path_with_namespace;
 
-                $("<td/>").addClass("name").append(
-                    $("<a/>").attr({href: project_url}).text(project.path_with_namespace)
-                ).appendTo(tr);
+                var span = $("<span/>");
+                if(project.archived){
+                    $("<span/>").addClass("glyphicon glyphicon-eye-close").appendTo(span);
+                }
+                $("<a/>").attr({href: project_url}).text(project.path_with_namespace).appendTo(span);
+                $("<td/>").addClass("name").append(span).appendTo(tr);
 
                 var project_option = config.getProject(project.id);
                 var events = gitlab.events();


### PR DESCRIPTION
* Sort by project name (for GitLab v7.7.0+)
* Add project archived icon

![2015-03-16 0 14 10](https://cloud.githubusercontent.com/assets/608755/6656617/5f064f72-cb72-11e4-9dcd-d9306e75aed6.png)