### PR TITLE
Fix API call with project_name

### DIFF
--- a/spec/gitlab_spec.js
+++ b/spec/gitlab_spec.js
@@ -46,7 +46,7 @@ describe("gitlab", function() {
         describe("when contains iid", function(){
             beforeEach(function() {
                 $.mockjax({
-                    url: 'http://example.com/api/v3/projects/gitlab%2Fgitlabhq/issues/42',
+                    url: 'http://example.com/api/v3/projects/12/issues/42',
                     responseText: stub.project_issue_v6
                 });
             });
@@ -54,7 +54,7 @@ describe("gitlab", function() {
             it("should get internal id url", function(){
                 var called = false;
 
-                gitlab.getEventInternalUrl({project_name: "gitlab/gitlabhq", target_type: "Issue", target_id: "42"}, function(url){
+                gitlab.getEventInternalUrl({project_name: "gitlab/gitlabhq", target_type: "Issue", target_id: "42", project_id: "12"}, function(url){
                     expect(url).toEqual("http://example.com/gitlab/gitlabhq/issues/3");
                     called = true;
                 });
@@ -72,7 +72,7 @@ describe("gitlab", function() {
         describe("when not contains iid", function(){
             beforeEach(function() {
                 $.mockjax({
-                    url: 'http://example.com/api/v3/projects/gitlab%2Fgitlabhq/issues/42',
+                    url: 'http://example.com/api/v3/projects/12/issues/42',
                     responseText: stub.project_issue_v5
                 });
             });
@@ -80,7 +80,7 @@ describe("gitlab", function() {
             it("should get global id url", function(){
                 var called = false;
 
-                gitlab.getEventInternalUrl({project_name: "gitlab/gitlabhq", target_type: "Issue", target_id: "42"}, function(url){
+                gitlab.getEventInternalUrl({project_name: "gitlab/gitlabhq", target_type: "Issue", target_id: "42", project_id: "12"}, function(url){
                     expect(url).toEqual("http://example.com/gitlab/gitlabhq/issues/42");
                     called = true;
                 });

--- a/src/background.js
+++ b/src/background.js
@@ -74,7 +74,8 @@ var background = (function(){
                         gitlab.getEventInternalId({
                             project_name: project.name,
                             target_type:  target_type,
-                            target_id:    project_event.target_id
+                            target_id:    project_event.target_id,
+                            project_id:   project_event.project_id, 
                         }, function(internal){
                             notification.notify({
                                 project:       project,

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -38,7 +38,7 @@ var gitlab= (function(){
     }
 
     function getEventInternalId(args, callback){
-        util.checkArgs(args, ["project_name", "target_type", "target_id"]);
+        util.checkArgs(args, ["project_name", "target_type", "target_id", "project_id"]);
 
         // Single issue
         // GET /projects/:id/issues/:issue_id
@@ -52,7 +52,7 @@ var gitlab= (function(){
         // GET /projects/:id/milestones/:milestone_id
         // https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/milestones.md#get-single-milestone
         $.ajax({
-            url: config.getApiPath() + "projects/" + encodeURIComponent(args.project_name) + "/" + eventPath[args.target_type].api + "/" + args.target_id,
+            url: config.getApiPath() + "projects/" + args.project_id + "/" + eventPath[args.target_type].api + "/" + args.target_id,
             type: "GET",
             dataType: "json",
             headers: {


### PR DESCRIPTION
When you use `encodeURIComponent(args.project_name)` Chrome return 404 error. When I try the encoded URL on my browser => 404. With the project_id I don't have this problem.