### PR TITLE
add a button to mark all notifications as read

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -67,6 +67,14 @@ app.view = function(vnode) {
         }, [
           m("i.fa.fa-gitlab[aria-hidden='true']"),
           "Go to GitLab"
+        ]),
+        m("button.goto.btn.btn-success", {
+          onclick: () => {
+            state.markAllAsRead();
+          }
+        }, [
+          m("i.fa.fa-check[aria-hidden='true']"),
+          "Mark all as read"
         ])
       ]),
     ]),

--- a/src/popup_init.js
+++ b/src/popup_init.js
@@ -27,6 +27,11 @@ window.onload = function() {
         config.clearCache();
       };
 
+      this.markAllAsRead = function () {
+        this.histories = [];
+        config.notifiedHistories = [];
+      };
+
       this.saveNotifiedHistories = function (histories) {
         config.notifiedHistories = histories;
       };


### PR DESCRIPTION
This feature introduce a button that will mark all notifications as read

![2017-09-20 10_28_37-](https://user-images.githubusercontent.com/14094226/30636852-e4282866-9df6-11e7-93f3-a6761560ea9b.png)
