### PR TITLE
Change merge request icon to code fork

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -135,7 +135,7 @@ app.view = function(vnode) {
               checked: project.events.MergeRequest ,
               onclick: m.withAttr("checked", (value) => { project.events.MergeRequest = value; } ),
             }),
-            m("i.fa.fa-check-square-o[title='MergeRequest' aria-hidden='true']"),
+            m("i.fa.fa-code-fork[title='MergeRequest' aria-hidden='true']"),
             "MergeRequest",
           ]),
         ]),

--- a/src/popup.js
+++ b/src/popup.js
@@ -46,7 +46,7 @@ app.view = function(vnode) {
       case "Issue":
         return m("i.fa.fa-exclamation-circle", {title: target_type});
       case "MergeRequest":
-        return m("i.fa.fa-check-square-o", {title: target_type});
+        return m("i.fa.fa-code-fork", {title: target_type});
       case "Milestone":
         return m("i.fa.fa-calendar", {title: target_type});
       case "Note":


### PR DESCRIPTION
Visually it's very unclear whats checked when icon for the a MergeRequest is a checkbox so this PR tries to fix that with the minimal changes possible to the fork icon.

**Original**
![image](https://user-images.githubusercontent.com/3750409/61333694-98389700-a7dc-11e9-8030-3a2b8215143e.png)

**Modified Options page**
![image](https://user-images.githubusercontent.com/3750409/61333188-15630c80-a7db-11e9-8880-b252d1e46e05.png)

**Modified Popup**
![image](https://user-images.githubusercontent.com/3750409/61333160-ff554c00-a7da-11e9-8b87-8563c6448b3e.png)

# Additional details
Ideally the gitlab icon ![image](https://user-images.githubusercontent.com/3750409/61334082-e00bee00-a7dd-11e9-856c-da185e7749cb.png) would be used but that seems like a bit of trouble to do quickly, or flipping the code fork icon might also be a option 😄.

